### PR TITLE
正誤表のコードをテーブル表示にして見やすくした

### DIFF
--- a/正誤表.md
+++ b/正誤表.md
@@ -11,80 +11,138 @@
 | XXXX | YYYY | ZZZZ |
 -->
 
-- ### P32/P34/P37 「生産量は在庫の範囲」という制約を定義する際に`stock[m]`直前で不要な改行がある
+<table>
+    <thead>
+        <tr>
+            <th scope="col">ページ</th>
+            <th scope="col">誤</th>
+            <th scope="col">正</th>
+        </tr>
+    </thead>
+<tbody>
+<!-- 1行開始 -->
+<tr>
+<td>
+P32/P34/P37
+</td>
+<td>
 
-誤
-```
+「生産量は在庫の範囲」という制約を定義する際に`stock[m]`直前で不要な改行がある
+
+```python
 for m in M:
     problem += pulp.lpSum([require[p,m] * x[p] for p in P]) <= 
 stock[m]
 ```
-正
-```
+
+</td>
+<td>
+
+```python
 for m in M:
     problem += pulp.lpSum([require[p,m] * x[p] for p in P]) <= stock[m]
 ```
+</td>
+</tr>
+<!-- 1行開始 -->
+<tr>
+<td>
+P67/P83
+</td>
+<td>
 
-
-- ### P67/P83 直前で定義したリストのペア`SS`を使っていない
+直前で定義したリストのペア`SS`を使っていない。  
 P67のコードでも正常動作するが、P61のコードをそのまま記述するのが正しい。
 
-誤
-```
+```py
 for row in s_pair_df.itertuples():
     s1 = row.student_id1
     s2 = row.student_id2
     for c in C:
         prob += x[s1,c] + x[s2,c] <= 1
 ```
-正
-```
+
+</td>
+<td>
+
+```py
 for s1, s2 in SS:
     for c in C:
         prob += x[s1,c] + x[s2,c] <= 1
 ```
+</td>
+</tr>
+<!-- 1行開始 -->
+<tr>
+<td>
+P223
+</td>
+<td>
 
-- ### P223の2つ目のコードブロックで改行記号（↩︎）が2箇所抜けている
+2つ目のコードブロックで改行記号（↩︎）が2箇所抜けている
 
-誤
-```
+```html
 <form name=download action="/download" method=post 
 enctype=multipart/form-data>
     <input type=hidden name=solution_html value="{{ 
 solution_html }}">
 ```
-正
-```
+
+</td>
+<td>
+
+```html
 <form name=download action="/download" method=post      ↩︎
 enctype=multipart/form-data>
     <input type=hidden name=solution_html value="{{     ↩︎
 solution_html }}">
 ```
+</td>
+</tr>
+<!-- 1行開始 -->
+<tr>
+<td>
+P264
+</td>
+<td>
 
-- ### P264/P269の`cvxopt`のimport
-P264のcvxoptのimportの仕方を修正し、同時にP269ではcvxoptをimportしないようにする。
-なお、P269のimportでタイポがある。
+cvxoptのimportの仕方を修正する。
 
-誤
-```
+```py
 from cvxopt import solvers
 ```
-正
-```
+
+</td>
+<td>
+
+```py
 import cvxopt
 ```
-
+</td>
+</tr>
+<!-- 1行開始 -->
+<tr>
+<td>
 P269
+</td>
+<td>
 
-誤
-```
+cvxoptをimportしないようにする。  
+なお、元のコードではimportのタイポ(inport)がある。
+
+```py
 inport cvxopt
 ```
-正
+
+</td>
+<td>
+
 ```
 ```
-
-
+</td>
+</tr>
+</tbody>
+</table>
 
 
 ## **本文**
@@ -95,7 +153,3 @@ inport cvxopt
 | P49 | 173,3 | 173.3 |
 | P54 | 8クラスをA〜Hのアルファベットで表しています。 | 8クラスをA〜Hのアルファベットで表すことにします。 |
 | P60 | ![x_{s1, c} + s_{s2, c} \leq 1](https://latex.codecogs.com/gif.latex?x_%7Bs1%2C%20c%7D%20&plus;%20s_%7Bs2%2C%20c%7D%20%5Cleq%201) | ![x_{s1, c} + x_{s2, c} \leq 1](https://latex.codecogs.com/gif.latex?x_%7Bs1%2C%20c%7D%20&plus;%20x_%7Bs2%2C%20c%7D%20%5Cleq%201) |
-
-
-
-


### PR DESCRIPTION
https://github.com/ohmsha/PyOptBook/blob/fix/errata-code-table/%E6%AD%A3%E8%AA%A4%E8%A1%A8.md